### PR TITLE
Adding files to init.pp so that we can create multiple resources

### DIFF
--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -27,7 +27,11 @@ define logrotate::file(
   $ensure = 'present',
   $postrotate = 'NONE'
 ) {
-  require logrotate
+  if !defined( Class[ 'logrotate' ] ) {
+    fail("require logrotate to run")
+  }
+  
+
 
   file { "/etc/logrotate.d/${name}":
     ensure  => $ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,8 @@ class logrotate (
   $rotate_every = 'weekly', # daily, weekly, monthly
   $rotate = 4,
   $compress = 'compress',
-  $options = []
+  $options = [],
+  $files = {}
 ) {
 
   package { 'logrotate':
@@ -33,4 +34,6 @@ class logrotate (
     content => template('logrotate/logrotate.conf.erb'),
     require => Package['logrotate'],
   }
+
+  create_resources(::logrotate::file, $logrotate::files)
 }


### PR DESCRIPTION
I have added the create_resources so that files if specified in hiera or elsewhere as a parameter can be created automatically. 
Sponsored by Baloise Group