### PR TITLE
set warning header inside template

### DIFF
--- a/templates/logrotate.conf.erb
+++ b/templates/logrotate.conf.erb
@@ -1,3 +1,4 @@
+# File maintained by puppet, do not modify
 # see "man logrotate" for details
 # rotate log files weekly
 <%= @rotate_every %>


### PR DESCRIPTION
Set warning header so people know where this file came from and why they're manual changes keep getting overwritten.